### PR TITLE
fix imports that may fail depending on the import order

### DIFF
--- a/eidos/create_beam.py
+++ b/eidos/create_beam.py
@@ -9,6 +9,8 @@ from util import *
 from spectral import *
 from spatial import *
 from parallelize import *
+
+import numpy as np
 import argparse
 
 def zernike_parameters(filename, npix=256, diameter=10, thr=20):

--- a/eidos/spatial.py
+++ b/eidos/spatial.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
+
 from util import *
+
+import numpy as np
 import math
 
 fac = math.factorial


### PR DESCRIPTION
Numpy is needed in those files. It is never imported directly, but always through a different file that has this import. Depending on where EIDOS is used, a different "util" could be included, which does not have a numpy import. Hence the import should always happend directly in the file where it is needed. 